### PR TITLE
Remove use of urlquote in feeds.

### DIFF
--- a/nomination/feeds.py
+++ b/nomination/feeds.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse
 from django.contrib.syndication.views import Feed, FeedDoesNotExist
 from nomination.views import get_project
-from django.utils.http import urlquote
 from django.utils.feedgenerator import Atom1Feed
 
 class url_feed(Feed):
@@ -35,7 +34,7 @@ class url_feed(Feed):
 
     def item_link(self, item):
         """Takes an item from items(), and returns its URL."""
-        return reverse('url_listing', args=[self.slug,urlquote(item.entity)])
+        return reverse('url_listing', args=[self.slug, item.entity])
 
     def item_pubdate(self, item):
         """Takes an item from items(), and returns its added date."""
@@ -93,7 +92,7 @@ class nomination_feed(Feed):
 
     def item_link(self, item):
         """Takes an item from items(), and returns its URL."""
-        return reverse('url_listing', args=[self.slug,urlquote(item.entity)])
+        return reverse('url_listing', args=[self.slug, item.entity])
 
     def item_pubdate(self, item):
         """Takes an item from items(), and returns its nomination date."""

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -76,7 +76,6 @@ class TestURLFeed:
         assert items[0] == surts[1]
         assert items[1] == surts[0]
 
-    @pytest.mark.xfail(reason='Manual use of urlquote inside of reverse produces different URL.')
     def test_item_link(self, rf):
         project = factories.ProjectFactory(project_slug='test_project')
         surt = factories.SURTFactory(url_project=project, entity='http://www.example.com')
@@ -231,7 +230,6 @@ class TestNominationFeed:
         assert items[0] == noms[1]
         assert items[1] == noms[0]
 
-    @pytest.mark.xfail(reason='Manual use of urlquote inside of reverse produces different URL.')
     def test_item_link(self, rf):
         project = factories.ProjectFactory(project_slug='test_project')
         nom = factories.NominatedURLFactory(url_project=project, entity='http://www.example.com')


### PR DESCRIPTION
Removing urlquote in the feeds will correct the invalid URLs currently being created. Fixes #45.