### PR TITLE
Move the input help texts to right below the input labels.

### DIFF
--- a/nomination/static/nomination/styles/local.css
+++ b/nomination/static/nomination/styles/local.css
@@ -15,6 +15,15 @@
     margin-top: 2em;
 }
 
+label {
+    margin-top: .7em;
+    margin-bottom: 0em;
+}
+
+.help-block {
+    margin-top: 0em;
+}
+
 .bold {
     font-weight: bold;
 }

--- a/nomination/templates/nomination/project_urls.html
+++ b/nomination/templates/nomination/project_urls.html
@@ -13,13 +13,13 @@
             <div class="panel-body">
                 <form method="post" role="form" action="{% url 'url_lookup' project.project_slug %}">{% csrf_token %}
                     <label for="search-url-value">Search by URL</label>
+                    <span class="help-block" id="helpBlock">Search for an existing URL in the system.</span>
                     <div class="input-group col-md-6">
                         <input type="text" class="form-control" name="search-url-value" id="search-url-value" aria-describedby="help-block" value="http://">
                         <span class="input-group-btn">
                             <button class="btn btn-primary" type="submit">submit</button>
                         </span>
                     </div>
-                    <span class="help-block" id="helpBlock">Search for an existing URL in the system.</span>
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" name="partial-search" value="true">

--- a/nomination/templates/nomination/url_add.html
+++ b/nomination/templates/nomination/url_add.html
@@ -50,6 +50,7 @@
                             {% endif %}
                             <div id="invalidUrlError" class="alert alert-danger hidden" role="alert">Cannot navigate to an invalid URL.</div>
                             <label for="title-value">Website URL: <span class="required-field">*</span></label>
+                            <p class="help-block">The URL you wish to nominate for capture</p>
                             <div class="input-group">
                                 {{ form.url_value|add_class:"form-control" }}
                                 <span class="input-group-btn">
@@ -58,7 +59,6 @@
                                     </button>
                                 </span>
                             </div>
-                            <p class="help-block">The URL you wish to nominate for capture</p>
                         </div>
                     </div>
                 </div>
@@ -80,8 +80,8 @@
                                         <label for="{{ met.metadata.name }}">{{ met.description }}: <span class="required-field">*</span></label>
                                     {% endifequal %}
                                     {% if met.form_type == "text" %}
-                                        <input class="form-control" type="text" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}">
                                         <p class="help-block">{{ met.help }}</p>
+                                        <input class="form-control" type="text" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}">
                                     {% elif met.form_type == "radio" %}
                                         <p class="help-block">{{ met.help }}</p>
                                         {% for val in vals %}
@@ -124,25 +124,25 @@
                                             {% endifnotequal%}
                                         {% endfor %}
                                     {% elif met.form_type == "select" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <select class="form-control" multiple size="6" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}">
                                             {% for val in vals %}
                                                 <option value="{{ val.key }}">{{ val.value }}</option>
                                             {% endfor %}
                                         </select>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "selectsingle" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <select class="form-control" size="6" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}">
                                             {% for val in vals %}
                                                 <option value="{{ val.key }}">{{ val.value }}</option>
                                             {% endfor %}
                                         </select>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "textarea" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <textarea class="form-control" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}"></textarea>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "date"  %}
-                                        <input class="form-control" type="date" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}" value="{{ vals|first }}"/>
                                         <p class="help-block">{{ met.help }}</p>
+                                        <input class="form-control" type="date" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}" value="{{ vals|first }}"/>
                                     {% endif %}
                                 </div>
                             {% endfor %}
@@ -165,8 +165,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ form.nominator_name|add_class:"form-control" }}
                             <p class="help-block">Please provide your name</p>
+                            {{ form.nominator_name|add_class:"form-control" }}
                         </div>
                         <div class="form-group">
                             {% if form_errors.nominator_institution %}
@@ -176,8 +176,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ form.nominator_institution|add_class:"form-control" }}
                             <p class="help-block">Please provide your institutional affiliation</p>
+                            {{ form.nominator_institution|add_class:"form-control" }}
                         </div>
                         <div class="form-group">
                             {% if form_errors.nominator_email %}
@@ -187,8 +187,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ form.nominator_email|add_class:"form-control" }}
                             <p class="help-block">Please provide an email address in order to identify your nominations in the system</p>
+                            {{ form.nominator_email|add_class:"form-control" }}
                         </div>
                         <input type="submit" value="submit" class="btn btn-primary" />
                     </div>

--- a/nomination/templates/nomination/url_listing.html
+++ b/nomination/templates/nomination/url_listing.html
@@ -116,8 +116,8 @@
                                     {% endif %}
                                     <label for="{{ met.metadata.name }}">{{ met.description }}:</label>
                                     {% if met.form_type == "text" %}
-                                        <input class="form-control" type="text" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}" />
                                         <p class="help-block">{{ met.help }}</p>
+                                        <input class="form-control" type="text" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}" />
                                     {% elif met.form_type == "radio" %}
                                         <p class="help-block">{{ met.help }}</p>
                                         {% for val in vals %}
@@ -160,25 +160,25 @@
                                             {% endifnotequal%}
                                         {% endfor %}
                                     {% elif met.form_type == "select" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <select class="form-control" multiple size="6" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}">
                                             {% for val in vals %}
                                                 <option value="{{ val.key }}">{{ val.value }}</option>
                                             {% endfor %}
                                         </select>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "selectsingle" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <select class="form-control" size="6" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}">
                                             {% for val in vals %}
                                                 <option value="{{ val.key }}">{{ val.value }}</option>
                                             {% endfor %}
                                         </select>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "textarea" %}
+                                        <p class="help-block">{{ met.help }}</p>
                                         <textarea class="form-control" name="{{ met.metadata.name }}" id="{{ met.metadata.name }}"></textarea>
-                                        <p class="help-block">{{ met.help }}</p>
                                     {% elif met.form_type == "date"  %}
-                                        <input class="form-control" type="date" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}" />
                                         <p class="help-block">{{ met.help }}</p>
+                                        <input class="form-control" type="date" id="{{ met.metadata.name }}" name="{{ met.metadata.name }}" />
                                     {% endif %}
                                 </div>
                             {% endfor %}
@@ -201,8 +201,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ scope_form.nominator_name|add_class:"form-control" }}
                             <p class="help-block">Please provide your name</p>
+                            {{ scope_form.nominator_name|add_class:"form-control" }}
                         </div>
                         <div class="form-group">
                             {% if form_errors.nominator_institution %}
@@ -212,8 +212,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ scope_form.nominator_institution|add_class:"form-control" }}
                             <p class="help-block">Please provide your institutional affiliation</p>
+                            {{ scope_form.nominator_institution|add_class:"form-control" }}
                         </div>
                         <div class="form-group">
                             {% if form_errors.nominator_email %}
@@ -223,8 +223,8 @@
                             {% if project.registration_required %}
                                 <span class="required-field">*</span>
                             {% endif %}
-                            {{ scope_form.nominator_email|add_class:"form-control" }}
                             <p class="help-block">Please provide an email address in order to identify your nominations in the system</p>
+                            {{ scope_form.nominator_email|add_class:"form-control" }}
                         </div>
                         <input type="submit" value="submit" class="btn btn-primary" />
                     </div>


### PR DESCRIPTION
ping @ldko, @jason-ellis, @jthomale 
What do you guys think about this? Look good? Switches the help text for the inputs to be right below the input label.

**BEFORE**
![screenshot from 2016-06-06 11 34 17](https://cloud.githubusercontent.com/assets/5580991/15829733/a210097e-2bda-11e6-9db8-e36e67bd94e2.png)

**AFTER**
![screenshot from 2016-06-06 11 32 10](https://cloud.githubusercontent.com/assets/5580991/15829692/6ae83c1e-2bda-11e6-86de-e8ee7043ef1e.png)
