### PR TITLE
Update docker-compose file to use version 2 syntax.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-web:
-    build: .
-    volumes:
-        - .:/app/
-    ports:
-        - "8000:80"
+version: '2'
+services:
+    web:
+        build: .
+        volumes:
+            - .:/app/
+        ports:
+            - "8000:80"


### PR DESCRIPTION
This is to make our docker-compose set-up compatible with current versions of docker-compose and docker-engine. "Version 2" syntax for docker-compose is what is now supported for docker-compose versions 1.6.0 going forward, while the old version is no longer supported as of version 1.7.0 (though not officially deprecated yet, it will be in some unspecified future version). Also the new syntax is supported in docker-engine > 1.10.0. So to if you want to test this change you may need to apt update your docker-engine and pip update your docker-compose. I plan on changing all our other docker-compose files as well so we can continue to use the latest updates.