### PR TITLE
Fix web server removing double slash is https URL.

### DIFF
--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from nomination.models import Project, Nominator, URL, Metadata, Value
 
 
-HTTP_ONE_SLASH = re.compile(r'http:/([^/])')
+HTTP_ONE_SLASH = re.compile(r'https?:/([^/])')
 
 def alphabetical_browse(project):
     browse_key_list = string.digits + string.uppercase


### PR DESCRIPTION
There was an issue where if you go to the main page for a Nomination project and search for a URL there to see if it exists and it does not exist, the tool takes you to a page to nominate the URL. On that page when it puts the URL into the nomination form for you automatically, the URL was only going in with one of the slashes in 'https://'.

ping @somexpert 