### PR TITLE
Fix double slash for ftp urls.

### DIFF
--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from nomination.models import Project, Nominator, URL, Metadata, Value
 
 
-SCHEME_ONE_SLASH = re.compile(r'(http|ftp)s?:/([^/])')
+SCHEME_ONE_SLASH = re.compile(r'(https?|ftps?):/([^/])')
 
 def alphabetical_browse(project):
     browse_key_list = string.digits + string.uppercase

--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from nomination.models import Project, Nominator, URL, Metadata, Value
 
 
-HTTP_ONE_SLASH = re.compile(r'https?:/([^/])')
+SCHEME_ONE_SLASH = re.compile(r'(http|ftp)s?:/([^/])')
 
 def alphabetical_browse(project):
     browse_key_list = string.digits + string.uppercase
@@ -609,7 +609,7 @@ def get_domain_surt(surt):
     else:
         return surt
 
-def fix_http_double_slash(http_string):
+def fix_scheme_double_slash(url):
     """Add back slash lost by Apache removing null path segments."""
-    fixed_entity = re.sub(HTTP_ONE_SLASH, r'http://\1', http_string)
+    fixed_entity = re.sub(SCHEME_ONE_SLASH, r'\1://\2', url)
     return fixed_entity

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -13,7 +13,7 @@ from nomination.models import Project, URL, Value, Nominator
 from django import forms
 from django.views.decorators.csrf import csrf_protect
 from nomination.url_handler import (add_url, create_json_browse,
-    create_url_list, create_json_search, add_metadata, fix_http_double_slash,
+    create_url_list, create_json_search, add_metadata, fix_scheme_double_slash,
     create_surt_dict, alphabetical_browse, get_metadata,
     handle_metadata, validate_date, create_url_dump)
 try:
@@ -173,7 +173,7 @@ def project_urls(request, slug):
 @csrf_protect
 def url_listing(request, slug, url_entity):
     # Add back the slash lost by Apache removing null path segments.
-    url_entity = fix_http_double_slash(url_entity) 
+    url_entity = fix_scheme_double_slash(url_entity) 
     url_exists = True
     posted_data = None
     # get the project by the project slug
@@ -346,7 +346,7 @@ def url_listing(request, slug, url_entity):
 
 def url_surt(request, slug, surt):
     # Add back the slash lost by Apache removing null path segments.
-    surt = fix_http_double_slash(surt)
+    surt = fix_scheme_double_slash(surt)
     # Get the project by the project slug.
     project = get_project(slug)
     # Create the SURT dictionary containing url_list and single_letter.
@@ -750,7 +750,7 @@ def field_report(request, slug, field):
 def value_report(request, slug, field, val):
     val = urllib.unquote(val)
     # Add back the slash lost by Apache removing null path segments.
-    val = fix_http_double_slash(val)
+    val = fix_scheme_double_slash(val)
     # Get the project by the project slug.
     project = get_project(slug)
     # If there are no URLs in the queryset, Apache rewrote the url,

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -730,7 +730,12 @@ def test_get_domain_surt(surt, expected):
     assert url_handler.get_domain_surt(surt) == expected
 
 
-def test_fix_http_double_slash():
+def test_fix_scheme_double_slash():
     url = 'http:/www.example.com'
     expected = 'http://www.example.com'
-    assert url_handler.fix_http_double_slash(url) == expected
+    assert url_handler.fix_scheme_double_slash(url) == expected
+
+def test_fix_scheme_double_slash_ftp():
+    url = 'ftp:/www.example.com/clvl37.idx'
+    expected = 'ftp://www.example.com/clvl37.idx'
+    assert url_handler.fix_scheme_double_slash(url) == expected


### PR DESCRIPTION
This is to allow access to the metadata page for ftp URLs if the web server strips the double slash from the URL being looked up. Created an [issue about further supporting ftp URLs](https://github.com/unt-libraries/django-nomination/issues/80).