### PR TITLE
Feed fix

### DIFF
--- a/nomination/feeds.py
+++ b/nomination/feeds.py
@@ -11,6 +11,10 @@ class url_feed(Feed):
     def get_object(self, request, slug):
         self.slug = slug
         self.project = get_project(self.slug)
+        self.site_names = dict(self.project.url_set.filter(attribute__iexact='Site_Name').values_list('entity', 'value'))
+        self.url_titles = dict(self.project.url_set.filter(attribute__iexact='Title').values_list('entity', 'value'))
+        self.descriptions = dict(self.project.url_set.filter(attribute__iexact='Description').values_list('entity', 'value'))
+
         return  self.project
 
     def title(self, obj):
@@ -45,17 +49,17 @@ class url_feed(Feed):
         # return url if there is no title
         title = item.entity
         try:
-            title = self.project.url_set.get(entity__exact=item.entity, attribute="Site_Name").value
+            title = self.site_names[item.entity]
         except:
             try:
-                title = self.project.url_set.get(entity__exact=item.entity, attribute="Title").value
+                title = self.url_titles[item.entity]
             except:
                 pass
         return title
 
     def item_description(self, item):
         try:
-            return "%s - %s" % (item.entity, self.project.url_set.get(entity__exact=item.entity, attribute="Description").value)
+            return "%s - %s" % (item.entity, self.descriptions[item.entity])
         except:
             return item.entity
 

--- a/nomination/feeds.py
+++ b/nomination/feeds.py
@@ -144,9 +144,13 @@ def no_dup_dict(url_set):
     key, no entries are made into the dictionary.
     """
     attr_dict = {}
+    del_list = []
     for entity, attribute in url_set:
         if entity in attr_dict:
-            del(attr_dict[entity])
+            del_list.append(entity)
         else:
             attr_dict[entity] = attribute
+    # For all the entities that had duplicates, delete the dict entry.
+    for entity in set(del_list):
+        del(attr_dict[entity])
     return attr_dict

--- a/nomination/feeds.py
+++ b/nomination/feeds.py
@@ -11,9 +11,9 @@ class url_feed(Feed):
     def get_object(self, request, slug):
         self.slug = slug
         self.project = get_project(self.slug)
-        self.site_names = dict(self.project.url_set.filter(attribute__iexact='Site_Name').values_list('entity', 'value'))
-        self.url_titles = dict(self.project.url_set.filter(attribute__iexact='Title').values_list('entity', 'value'))
-        self.descriptions = dict(self.project.url_set.filter(attribute__iexact='Description').values_list('entity', 'value'))
+        self.site_names = dict(self.project.url_set.filter(attribute__iexact='Site_Name').order_by('-date').values_list('entity', 'value'))
+        self.url_titles = dict(self.project.url_set.filter(attribute__iexact='Title').order_by('-date').values_list('entity', 'value'))
+        self.descriptions = dict(self.project.url_set.filter(attribute__iexact='Description').order_by('-date').values_list('entity', 'value'))
 
         return  self.project
 

--- a/nomination/feeds.py
+++ b/nomination/feeds.py
@@ -11,6 +11,7 @@ class url_feed(Feed):
     def get_object(self, request, slug):
         self.slug = slug
         self.project = get_project(self.slug)
+        # Save these dicts of URLs/attributes so we don't have to query the DB again later.
         self.site_names = dict(self.project.url_set.filter(attribute__iexact='Site_Name').order_by('-date').values_list('entity', 'value'))
         self.url_titles = dict(self.project.url_set.filter(attribute__iexact='Title').order_by('-date').values_list('entity', 'value'))
         self.descriptions = dict(self.project.url_set.filter(attribute__iexact='Description').order_by('-date').values_list('entity', 'value'))
@@ -49,9 +50,11 @@ class url_feed(Feed):
         # return url if there is no title
         title = item.entity
         try:
+            # Check the saved dict of URLs/site names.
             title = self.site_names[item.entity]
         except:
             try:
+                # Check the saved dict of URLs/titles.
                 title = self.url_titles[item.entity]
             except:
                 pass
@@ -59,6 +62,7 @@ class url_feed(Feed):
 
     def item_description(self, item):
         try:
+            # Check the saved dict of URLs/descriptions.
             return "%s - %s" % (item.entity, self.descriptions[item.entity])
         except:
             return item.entity
@@ -113,9 +117,11 @@ class nomination_feed(Feed):
         # return url if there is no title
         title = item.entity
         try:
+            # Check saved dict of URLs/site names.
             title = self.site_names[item.entity]
         except:
             try:
+                # Check saved dict of URLs/titles.
                 title = self.url_titles[item.entity]
             except:
                 pass
@@ -123,6 +129,7 @@ class nomination_feed(Feed):
 
     def item_description(self, item):
         try:
+            # Check the saved dict of URLs/descriptions.
             return "%s - %s" % (item.entity, self.descriptions[item.entity])
         except:
             return item.entity


### PR DESCRIPTION
Currently the feeds for URLs and nominations can be extremely slow when there are many nominated URLs. This is because of the huge amount of queries being done by the feeds in those cases. This is a fix that significantly reduces the total # of database queries needed.