### PR TITLE
Store https urls

### DIFF
--- a/nomination/templates/nomination/project_urls.html
+++ b/nomination/templates/nomination/project_urls.html
@@ -15,7 +15,7 @@
                     <label for="search-url-value">Search by URL</label>
                     <span class="help-block" id="helpBlock">Search for an existing URL in the system.</span>
                     <div class="input-group col-md-6">
-                        <input type="text" class="form-control" name="search-url-value" id="search-url-value" aria-describedby="help-block" value="http://">
+                        <input type="text" class="form-control" name="search-url-value" id="search-url-value" aria-describedby="help-block">
                         <span class="input-group-btn">
                             <button class="btn btn-primary" type="submit">submit</button>
                         </span>

--- a/nomination/templates/nomination/project_urls.html
+++ b/nomination/templates/nomination/project_urls.html
@@ -47,7 +47,7 @@
                 {% for top_domain,domain_list in browse_tup %}
                     <li class="list-group-item">
                         <h3>
-                            <a href="/nomination/{{ project.project_slug }}/surt/http://({{ top_domain }}/">
+                            <a href="/nomination/{{ project.project_slug }}/surt/({{ top_domain }}/">
                                 {{ top_domain }}
                             </a>
                         </h3>

--- a/nomination/templates/nomination/url_surt.html
+++ b/nomination/templates/nomination/url_surt.html
@@ -30,7 +30,7 @@
                 <div class="panel panel-primary">
                     <div class="panel-heading">
                         <h4 class="panel-title">Browse
-                            <a href="/nomination/{{ project.project_slug }}/surt/http://({{ browse_domain }}/">
+                            <a href="/nomination/{{ project.project_slug }}/surt/({{ browse_domain }}/">
                                 {{ browse_domain }}
                             </a> URLs
                         </h4>

--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -4,6 +4,7 @@ import json
 import re
 import string
 import time
+from urlparse import urlparse
 
 from django import http
 from django.conf import settings
@@ -616,3 +617,8 @@ def fix_scheme_double_slash(url):
     """Add back slash lost by Apache removing null path segments."""
     fixed_entity = re.sub(SCHEME_ONE_SLASH, r'\1://\2', url)
     return fixed_entity
+
+def strip_scheme(url):
+    """Remove scheme from URL."""
+    scheme = '{}://'.format(urlparse(url).scheme)
+    return url.replace(scheme, '', 1)

--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -329,6 +329,8 @@ def surtize(orig_url, preserveCase=False):
     # start building surt form
     if mobj.group(1) == 'https://':
         surt = 'http://('
+    elif mobj.group(1) == 'ftps://':
+        surt = 'ftp://('
     else:
         surt = mobj.group(1) + '('
     # if dotted-quad ip match, don't reverse

--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -1,6 +1,13 @@
-import string, re, simplejson, itertools, datetime, time
+import datetime
+import itertools
+import json
+import re
+import string
+import time
+
 from django import http
 from django.conf import settings
+
 from nomination.models import Project, Nominator, URL, Metadata, Value
 
 
@@ -149,10 +156,6 @@ def add_metadata(project, form_data):
 
 def check_url(url):
     url = string.strip(url)
-    if url.count('http://') > 1:
-        url = url.replace('http://', '', 1)
-    if url.startswith('https://'):
-        url = url.replace('https://', 'http://', 1)
     url = addImpliedHttpIfNecessary(url)
     url = url.rstrip('/')
     return url
@@ -458,7 +461,7 @@ def create_json_browse(slug, url_attribute, root):
             if len(domain_dict) > 0:
                 json_list.append(domain_dict)
 
-    return simplejson.dumps(json_list)
+    return json.dumps(json_list)
 
 def create_json_search(slug):
     """Create JSON list of all URLs added to the specified project."""
@@ -475,7 +478,7 @@ def create_json_search(slug):
     for url_item in query_list:
         json_list.append(url_item)
 
-    return simplejson.dumps(json_list)
+    return json.dumps(json_list)
 
 def create_url_list(project, base_list):
     url_dict = {}

--- a/nomination/url_handler.py
+++ b/nomination/url_handler.py
@@ -13,6 +13,7 @@ from nomination.models import Project, Nominator, URL, Metadata, Value
 
 
 SCHEME_ONE_SLASH = re.compile(r'(https?|ftps?):/([^/])')
+ANCHOR_PATTERN = re.compile(r'^<a href=\"[^>]+>([^<]+)</a>')
 
 def alphabetical_browse(project):
     browse_key_list = string.digits + string.uppercase
@@ -23,8 +24,8 @@ def alphabetical_browse(project):
         raise http.Http404
 
     #compile regex
-    topdom_rgx = re.compile(r'^http://\(([^,]+),')
-    singdom_rgx = re.compile(r'^http://\([^,]+,([^,\)]{1})')
+    topdom_rgx = re.compile(r'^[^:]+://\(([^,]+),')
+    singdom_rgx = re.compile(r'^[^:]+://(\([^,]+,([^,\)]{1}))')
 
     for url_item in surt_list:
         top_domain_search = topdom_rgx.search(url_item.value, 0)
@@ -36,11 +37,11 @@ def alphabetical_browse(project):
                     browse_dict[top_domain][key] = None
             domain_single_search = singdom_rgx.search(url_item.value, 0)
             if domain_single_search:
-                domain_single = string.upper(domain_single_search.group(1))
-                browse_dict[top_domain][domain_single] = domain_single_search.group(0)
+                domain_single = string.upper(domain_single_search.group(2))
+                browse_dict[top_domain][domain_single] = domain_single_search.group(1)
 
     sorted_dict = {}
-    for top_domain,alpha_dict in browse_dict.items():
+    for top_domain, alpha_dict in browse_dict.items():
         alpha_list = []
         for key in sorted(alpha_dict.iterkeys()):
             alpha_list.append((key, alpha_dict[key],))
@@ -371,7 +372,7 @@ def addImpliedHttpIfNecessary(uri):
        uri = 'http://' + uri
     return uri
 
-def create_json_browse(slug, url_attribute, root):
+def create_json_browse(slug, url_attribute, root=''):
     """Create a JSON list which can be used to represent a tree of the SURT domains.
 
     If a root is specified, the JSON list will show just the tree of domains under
@@ -389,60 +390,53 @@ def create_json_browse(slug, url_attribute, root):
 
     if root != '':
         #Find all URLs with the project and domain specified
-        try:
-            url_list = URL.objects.filter(url_project=project, attribute__iexact='surt', value__icontains=root).order_by('value')
-        except:
-            return ''
+        url_list = URL.objects.filter(url_project=project, attribute__iexact='surt', value__icontains=root).order_by('value')
     else:
         #Find all URLs with the project specified (the base domains)
-        try:
-            url_list = URL.objects.filter(url_project=project, attribute__iexact='surt').order_by('value')
-        except:
-            return ''
+        url_list = URL.objects.filter(url_project=project, attribute__iexact='surt').order_by('value')
 
     if len(url_list) >= 100 and root != '':
         category_list = []
         for url_item in url_list:
-            name_search = re.compile(r'^http://\('+root+'([A-Za-z0-9]{1})').search(url_item.value, 0)
+            name_search = re.compile(r'^[^:]+://\('+root+'([A-Za-z0-9]{1})').search(url_item.value, 0)
             if name_search:
                 if not name_search.group(1) in category_list:
                     category_list.append(name_search.group(1))
         for category in category_list:
             category_dict = {'text': category,
-                                       'id': root+category,
-                                       'hasChildren': True
-                                      }
+                             'id': root+category,
+                             'hasChildren': True
+                            }
             json_list.append(category_dict)
     else:
+        name_pattern = re.compile(r'^[^:]+://\('+root+'([^,\)]+)')
+        child_pattern = re.compile(r'^[^:]+://\('+root+'[^,]+,[^,\)]+')
         for url_item in url_list:
             domain_dict = {}
             #Determine if URL is a child of the expanded node
-            name_search = re.compile(r'^http://\('+root+'([^,\)]+)').search(url_item.value, 0)
+            name_search = name_pattern.search(url_item.value, 0)
             #if the URL exists under the expanded node
             if name_search:
                 #Determine if the URL has children
-                child_found = re.compile(r'^http://\('+root+'[^,]+,[^,\)]+').search(url_item.value, 0)
+                child_found = child_pattern.search(url_item.value, 0)
                 #Create a new domain name for the new URL
-                domain_name = root+name_search.group(1)
+                domain_name = root + name_search.group(1)
                 domain_not_found = True
                 #For all URLs in the json list already
                 for existing_domain in json_list:
                     #Find the domain name within the anchor
-                    found_anchor = re.compile(r'^<a href=\"[^>]+>([^<]+)</a>').search(existing_domain['text'], 0)
+                    found_anchor = ANCHOR_PATTERN.search(existing_domain['text'], 0)
                     if found_anchor:
                         removed_anchor = found_anchor.group(1)
                     else:
                         removed_anchor = None
-                    #if the domain name already exist in the json list
+                    #if the domain name already exists in the json list
                     if existing_domain['text'] == domain_name or removed_anchor == domain_name:
                         domain_not_found = False
-                        #if the domain name already exists in the json list, and it isn't listed as having children
-                        if child_found and not 'hasChildren' in existing_domain:
-                            existing_domain['hasChildren'] = True
                 #if the domain hasn't been added already, and it has a child node
                 if domain_not_found and child_found:
                     if len(domain_name.split(',')) > 1:
-                        domain_dict = {'text': '<a href=\"surt/http://('+ \
+                        domain_dict = {'text': '<a href=\"surt/('+ \
                             domain_name+'\">'+ \
                             domain_name+'</a>',
                                        'id': domain_name+',',
@@ -455,7 +449,7 @@ def create_json_browse(slug, url_attribute, root):
                                       }
                 #otherwise if the domain hasn't been added already, and it has no child
                 elif domain_not_found:
-                    domain_dict = {'text': '<a href=\"surt/http://('+ \
+                    domain_dict = {'text': '<a href=\"surt/('+ \
                         domain_name+'\">'+ \
                         domain_name+'</a>',
                                    'id': domain_name+','
@@ -587,17 +581,29 @@ def create_url_dump(project):
     return url_dict
 
 def create_surt_dict(project, surt):
-    try:
-        url_list = URL.objects.filter(
-            url_project=project,
-            attribute__iexact='surt',
-            value__istartswith=surt
-        ).order_by('value')
-    except:
-        url_list = None
+    if strip_scheme(surt) == surt:
+        # SURTs with no scheme are ok
+        surt_pattern = r'^[^:]+://\{0}'.format(strip_scheme(surt))
+        try:
+            url_list = URL.objects.filter(
+                url_project=project,
+                attribute__iexact='surt',
+                value__iregex=surt_pattern
+            ).order_by('value')
+        except:
+            url_list = None
+    else:
+        try:
+            url_list = URL.objects.filter(
+                url_project=project,
+                attribute__iexact='surt',
+                value__istartswith=surt
+            ).order_by('value')
+        except:
+            url_list = None
 
     letter = False
-    single_letter_search = re.compile(r'^http://\([^,]+,([^,\)]+)').search(surt, 0)
+    single_letter_search = re.compile(r'^(?:[^:]+://)?\([^,]+,([^,\)]+)').search(surt, 0)
     if single_letter_search:
         result = single_letter_search.group(1)
         if len(result) == 1:
@@ -609,7 +615,7 @@ def create_surt_dict(project, surt):
     }
 
 def get_domain_surt(surt):
-    domain_surt = re.compile(r'^(http://\([^,]+,[^,]+,)').search(surt, 0)
+    domain_surt = re.compile(r'^([^:]+://\([^,]+,[^,]+,)').search(surt, 0)
     if domain_surt:
         return domain_surt.group(1)
     else:

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -343,7 +343,7 @@ def url_surt(request, slug, surt):
     # Create the alphabetical browse dictionary.
     browse_dict = alphabetical_browse(project)
     # Add Browse by if browsing surts by letter.
-    top_domain_search = re.compile(r'^http://\(([^,]+),?').search(surt, 0)
+    top_domain_search = re.compile(r'^(?:[^:]+://)?\(([^,]+),?').search(surt, 0)
     if top_domain_search:
         top_domain = top_domain_search.group(1)
     else:

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -614,7 +614,9 @@ def surt_report(request, slug):
 
     #get the list of URLs
     try:
-        surt_list = URL.objects.filter(attribute__iexact='surt', url_project=project).order_by('value')
+        surt_list = URL.objects.filter(attribute__iexact='surt',
+                                       url_project=project).values_list('value',
+                                                                        flat=True).distinct().order_by('value')
     except:
         raise http.Http404
 
@@ -623,7 +625,7 @@ def surt_report(request, slug):
     " project.\n#SURTs sorted by SURT\n#List generated on " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%SZ") + "\n\n"
 
     for url_item in surt_list:
-        report_text += url_item.value + "\n"
+        report_text += url_item + "\n"
 
     return HttpResponse(report_text, content_type='text/plain; charset="UTF-8"')
 

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -738,3 +738,8 @@ def test_fix_scheme_double_slash_ftp():
     url = 'ftp:/www.example.com/clvl37.idx'
     expected = 'ftp://www.example.com/clvl37.idx'
     assert url_handler.fix_scheme_double_slash(url) == expected
+
+def test_strip_scheme():
+    url = 'https://example.com'
+    expected = 'example.com'
+    assert url_handler.strip_scheme(url) == expected

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -20,9 +20,9 @@ class TestAlphabeticalBrowse():
 
     def test_returns_browse_dict(self):
         surts = {
-            'A': ('http://(org,alarm,)', 'http://(org,a'),
-            'C': ('http://(org,charlie,)', 'http://(org,c'),
-            '1': ('http://(org,123,)', 'http://(org,1')
+            'A': ('http://(org,alarm,)', '(org,a'),
+            'C': ('http://(org,charlie,)', '(org,c'),
+            '1': ('http://(org,123,)', '(org,1')
         }
         project = factories.ProjectFactory()
         # Create the surts we're expecting to see represented in the returned dict.
@@ -469,7 +469,7 @@ def test_addImpliedHttpIfNecessary(uri, expected):
 class TestCreateJsonBrowse():
 
     @pytest.mark.parametrize('root, text, id_group', [
-        ('com,', '<a href="surt/http://(com,example">com,example</a>', 'com,example,'),
+        ('com,', '<a href="surt/(com,example">com,example</a>', 'com,example,'),
         ('', 'com', 'com,')
     ])
     def test_returns_expected(self, root, text, id_group):
@@ -478,6 +478,26 @@ class TestCreateJsonBrowse():
             url_project=project,
             entity='http://www.example.com',
             value='http://(com,example,www)'
+        )
+        expected = [{
+            'hasChildren': True,
+            'id': id_group,
+            'text': text
+        }]
+        results = url_handler.create_json_browse(project.project_slug, None, root)
+
+        assert json.loads(results) == expected
+
+    @pytest.mark.parametrize('root, text, id_group', [
+        ('com,', '<a href="surt/(com,example">com,example</a>', 'com,example,'),
+        ('', 'com', 'com,')
+    ])
+    def test_handles_non_http(self, root, text, id_group):
+        project = factories.ProjectFactory()
+        factories.SURTFactory(
+            url_project=project,
+            entity='ftp://www.example.com',
+            value='ftp://(com,example,www)'
         )
         expected = [{
             'hasChildren': True,
@@ -498,14 +518,14 @@ class TestCreateJsonBrowse():
         root = 'com,example,'
         expected = [{
             'id': 'com,example,www,',
-            'text': '<a href="surt/http://(com,example,www">com,example,www</a>'
+            'text': '<a href="surt/(com,example,www">com,example,www</a>'
         }]
         results = url_handler.create_json_browse(project.project_slug, None, root)
 
         assert json.loads(results) == expected
 
     @pytest.mark.parametrize('root, text, id_group', [
-        ('com,', '<a href="surt/http://(com,example">com,example</a>', 'com,example,'),
+        ('com,', '<a href="surt/(com,example">com,example</a>', 'com,example,'),
         ('', 'com', 'com,'),
     ])
     def test_does_not_show_duplicates(self, root, text, id_group):
@@ -515,6 +535,11 @@ class TestCreateJsonBrowse():
             url_project=project,
             entity='http://www.example.com',
             value='http://(com,example,www)'
+        )
+        factories.SURTFactory(
+            url_project=project,
+            entity='ftp://www.example.com',
+            value='ftp://(com,example,www)'
         )
         expected = [{
             'hasChildren': True,

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -435,6 +435,8 @@ def test_url_formatter(url, expected):
     ('http://userinfo@domain.tld:80/path?query#fragment', False,
         'http://(tld,domain,:80@userinfo)/path?query#fragment'),
     ('http://www.example.com', False, 'http://(com,example,www,)'),
+    ('ftp://www.example.com', False, 'ftp://(com,example,www,)'),
+    ('ftps://www.example.com', False, 'ftp://(com,example,www,)'),
     ('https://www.example.com', False, 'http://(com,example,www,)'),
     ('www.example.com', False, 'http://(com,example,www,)'),
     ('http://www.eXaMple.cOm', True, 'http://(cOm,eXaMple,www,)'),

--- a/tests/test_url_handler.py
+++ b/tests/test_url_handler.py
@@ -218,8 +218,7 @@ class TestAddMetadata():
 @pytest.mark.parametrize('url, expected', [
     ('http://www.example.com', 'http://www.example.com'),
     ('   http://www.example.com   ', 'http://www.example.com'),
-    ('https://www.example.com', 'http://www.example.com'),
-    ('http://http://www.example.com', 'http://www.example.com'),
+    ('https://www.example.com', 'https://www.example.com'),
     ('http://www.example.com///', 'http://www.example.com')
 ])
 def test_check_url(url, expected):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from django.core.urlresolvers import reverse
 from django.contrib.sites.models import Site
 from django.conf import settings
+from django.utils.http import urlquote
 
 from nomination import views, models
 from . import factories
@@ -93,6 +94,64 @@ class TestUrlLookup():
 
         assert response.status_code == 302
         assert response['Location'] == '/nomination/{0}/url/a_url/'.format(project.project_slug)
+
+    def test_empty_search_url_value_no_partial_search(self, client):
+        """Verify no URL value and no partial search returns all URLs."""
+        project = factories.ProjectFactory()
+        factories.URLFactory.create_batch(
+            3,
+            url_project=project,
+            attribute='surt'
+        )
+        response = client.post(
+            reverse('url_lookup',
+            args=[project.project_slug]),
+            {'search-url-value': ''}
+        )
+        assert len(response.context['url_list']) == 3
+
+    def test_partial_search_is_scheme_agnostic(self, client):
+        project = factories.ProjectFactory()
+        factories.URLFactory(url_project=project,
+                                        attribute='surt')
+        http_url = factories.URLFactory(url_project=project,
+                                        entity='http://example.com',
+                                        attribute='surt')
+        https_url = factories.URLFactory(url_project=project,
+                                         entity='https://example.com/stuff',
+                                         attribute='surt')
+        response = client.post(
+            reverse('url_lookup',
+                    args=[project.project_slug]),
+                    {'search-url-value': http_url.entity, 'partial-search': ''}
+        )
+        assert len(response.context['url_list']) == 2
+        assert https_url in response.context['url_list']
+
+    def test_exact_lookup_prefers_exact_scheme(self, rf):
+        project = factories.ProjectFactory()
+        url = factories.URLFactory(url_project=project,
+                                   entity='http://example.com',
+                                   attribute='surt')
+        factories.URLFactory(url_project=project,
+                             entity='https://example.com',
+                             attribute='surt')
+        request = rf.post('/', {'search-url-value': 'http://example.com'})
+        response = views.url_lookup(request, project.project_slug)
+
+        assert response['Location'] == '/nomination/{0}/url/{1}/'.format(project.project_slug,
+                                                                         urlquote(url.entity))
+
+    def test_exact_lookup_allows_alternate_scheme(self, rf):
+        project = factories.ProjectFactory()
+        url = factories.URLFactory(url_project=project,
+                                   entity='https://example.com',
+                                   attribute='surt')
+        request = rf.post('/', {'search-url-value': 'http://example.com'})
+        response = views.url_lookup(request, project.project_slug)
+
+        assert response['Location'] == '/nomination/{0}/url/{1}/'.format(project.project_slug,
+                                                                         urlquote(url.entity))
 
     def test_raises_http404_if_not_post(self, rf):
         project = factories.ProjectFactory()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -697,7 +697,7 @@ class TestBrowseJson():
 
     @pytest.mark.parametrize('request_type, kwargs, id, text', [
         ('get', {'root': 'com,'}, 'com,example,',
-         '<a href="surt/http://(com,example">com,example</a>'),
+         '<a href="surt/(com,example">com,example</a>'),
         ('get', {'root': 'source'}, 'com,', 'com'),
         ('get', {}, 'com,', 'com'),
         ('post', {}, 'com,', 'com')


### PR DESCRIPTION
Previously we forced all URIs to be stored with http:// scheme (not allowing https). This makes changes to allow for both (and others such as ftp://) to be stored and browsed. This should fix #26 and fix #31 (both regarding unreachable branches), close #67 (`http://` scheme initialized in forms), fix #80 (ftp browsing), and fix #38 (compile regex out of loop).

Please review when you get a chance @somexpert @runderwood 