### PR TITLE
Always send form_types to /url/.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ x.x.x
 * Improved a URL regex to only accept numbers for a numerical ID.
 * Used get_object_or_404 where appropriate to mitigate server errors.
 * Fixed a flake8 indentation error.
+* Upgraded compatibility to  Python 3.7
+* Removed compatibility with Django 1.10
+* Removed compatibility with Python 2
+* Added slim-select for improved select inputs
 
 
 2.0.0

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -183,6 +183,11 @@ def url_listing(request, slug, url_entity):
     # get the project by the project slug
     project = get_object_or_404(Project, project_slug=slug)
 
+    # send form types for use to repopulate form and for slim-select instantiation
+    form_types = {}
+    for pm in project.project_metadata_set.all():
+        form_types[pm.metadata.name] = str(pm.form_type)
+
     # get list of institutions to populate autocomplete
     institutions = get_look_ahead(project)
 
@@ -309,11 +314,6 @@ def url_listing(request, slug, url_entity):
         if posted_data:
             json_data = json.dumps(list(posted_data.lists()))
 
-        # send form types for use to repopulate form
-        form_types = {}
-        for pm in project.project_metadata_set.all():
-            form_types[pm.metadata.name] = str(pm.form_type)
-
         return render(
             request,
             'nomination/url_listing.html',
@@ -344,7 +344,7 @@ def url_listing(request, slug, url_entity):
              'form_errors': None,
              'summary_list': None,
              'json_data': None,
-             'form_types': None,
+             'form_types': json.dumps(form_types),
              'institutions': institutions,
              'url_entity': url_entity,
             },

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -276,6 +276,7 @@ class TestUrlListing():
     def test_context_url_not_found(self, client):
         entity = 'http://www.example.com'
         project = factories.ProjectFactory()
+        project_metadata = factories.ProjectMetadataFactory(project=project)
         response = client.get(reverse('url_listing', args=[project.project_slug, entity]))
         expected_context = {
             'project': project,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -285,7 +285,7 @@ class TestUrlListing():
             'form_errors': None,
             'summary_list': None,
             'json_data': None,
-            'form_types': None,
+            'form_types': json.dumps({project_metadata.metadata.name: project_metadata.form_type}),
             'institutions': views.get_look_ahead(project),
             'url_entity': entity,
         }


### PR DESCRIPTION
The form_types, which the /url/ template uses to instantiate the slim-select inputs, wasn't being populated when the URL was new for the project, resulting in plain inputs when they should have been slim-selects. This fixes that issue.