### PR TITLE
Remove duplicates from url_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ x.x.x
 * Removed compatibility with Django 1.10
 * Removed compatibility with Python 2
 * Added slim-select for improved select inputs
+* Prevent duplicates in url_report if a surt is duplicated in the data.
 
 
 2.0.0

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -623,12 +623,11 @@ def url_report(request, slug):
         raise http.Http404
 
     # Create the first two lines of the report file
-    report_text = '#This list of urls was created for the ' + project.project_name + \
-                  ' project.\n#Unique URLs sorted by SURT\n#List generated on ' + \
-                  datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
+    report_header = '#This list of urls was created for the ' + project.project_name + \
+                    ' project.\n#Unique URLs sorted by SURT\n#List generated on ' + \
+                    datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
 
-    for url_item in url_list:
-        report_text += url_item + '\n'
+    report_text = report_header + '\n'.join(url_list)
 
     return HttpResponse(report_text, content_type='text/plain; charset="UTF-8"')
 
@@ -647,12 +646,11 @@ def surt_report(request, slug):
         raise http.Http404
 
     # Create the first two lines of the report file
-    report_text = '#This list of SURTs was created for the ' + project.project_name + \
-                  ' project.\n#SURTs sorted by SURT\n#List generated on ' + \
-                  datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
+    report_header = '#This list of SURTs was created for the ' + project.project_name + \
+                    ' project.\n#SURTs sorted by SURT\n#List generated on ' + \
+                    datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
 
-    for url_item in surt_list:
-        report_text += url_item + '\n'
+    report_text = report_header + '\n'.join(surt_list)
 
     return HttpResponse(report_text, content_type='text/plain; charset="UTF-8"')
 

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -618,7 +618,7 @@ def url_report(request, slug):
         url_list = URL.objects.filter(
             attribute__iexact='surt',
             url_project=project
-        ).order_by('value')
+        ).order_by('value').values_list('entity', flat=True).distinct()
     except Exception:
         raise http.Http404
 
@@ -628,7 +628,7 @@ def url_report(request, slug):
                   datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
 
     for url_item in url_list:
-        report_text += url_item.entity + "\n"
+        report_text += url_item + '\n'
 
     return HttpResponse(report_text, content_type='text/plain; charset="UTF-8"')
 
@@ -652,7 +652,7 @@ def surt_report(request, slug):
                   datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%SZ') + '\n\n'
 
     for url_item in surt_list:
-        report_text += url_item + "\n"
+        report_text += url_item + '\n'
 
     return HttpResponse(report_text, content_type='text/plain; charset="UTF-8"')
 


### PR DESCRIPTION
This small change is to remove duplicates from the url report given at `nomination/eth2016_bulk/reports/urls/` (you can compare our dev vs. production instances of the tool). The report is based on the surt value in the data, of which they should be unique if data is only entered through the web interface. However, if data is loaded by script on the backend, as we do with our "_bulk" projects, they could have had surt duplicated. This change should suppress display of duplicates in the url report. 

This is ready for review ping @madhulika95b @somexpert 