### PR TITLE
Improve batch ingest and convert to Django management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed nominating URLs of length 255-300 chars by ensuring `value` is big enough to hold the URL's SURT value. [#114](https://github.com/unt-libraries/django-nomination/issues/114)
 * Fixed browsing from listing page to top-level domain SURT URLs. [#115](https://github.com/unt-libraries/django-nomination/issues/115)
 * Fixed links in URL lookup search results that needed encoding. [#118](https://github.com/unt-libraries/django-nomination/issues/118)
+* Converted fielded_batch_ingest.py script to a Django management command and improved speed.
 
 
 4.0.0

--- a/README.md
+++ b/README.md
@@ -77,19 +77,19 @@ Developing
 
 4. Start the container as a daemon.
     ```sh
-        $ docker-compose up -d
-        # Use 'docker-compose stop' to stop the container.
+        $ docker compose up -d
+        # Use 'docker compose stop' to stop the container.
     ```
     At this point you should be able to access your local instance of the site by visiting `<dockerhost>:8000/nomination/`.
 
 5. Create a superuser for access to the admin sites.
     ```sh
-        $ docker-compose run --rm web python manage.py createsuperuser
+        $ docker compose run --rm web python manage.py createsuperuser
     ```
 
 6. If desired, run the tests.
     ```sh
-        $ docker-compose run --rm web tox
+        $ docker compose run --rm web tox
     ```
 
 If you are on RHEL, your installation and commands may be different.

--- a/README.md
+++ b/README.md
@@ -125,20 +125,40 @@ If you are on RHEL, your installation and commands may be different.
         $ sudo podman-compose run --rm web tox
     ```
 
+Batch Ingest Management Command
+-------------------------------
+
+For bulk loading of URL nominations into a Nomination Tool instance,
+there is a `fielded_batch_ingest` management command. Input file formats
+include:
+
+* text file - one URL per line
+* CSV - lines contain a `url` field as well as additional arbitrary metadata fields that must be named on the first line (e.g. the first line of the CSV might look like `url,Title,List_Name`)
+* pickled dictionary - serialized Python object in pickle format. This allows multivalued attributes that can be stored in a Python dictionary as lists.
+
+To view details on this bulk loading tool, run:
+```sh
+    $ python manage.py fielded_batch_ingest -h
+```
+
+For example, to load a CSV file:
+```sh
+    $ python manage.py fielded_batch_ingest tests/data/test.csv --nominator 2 --project project1 --csv
+```
+
+
 Helper Scripts
 --------------
 
-There are three scripts made available with this app that can help with batch
+There are two scripts made available with this app that can help with batch
 uploading of project information, such as project metadata and URL nominations.
 They are located in the user_scripts subdirectory and are intended to be run
 from the machine serving the app. They require access to the settings file used
 by the Django project hosting the app. If you are serving the app using a virtual
 environment, the script will need to be run from within that same environment.
-The three scripts are well-commented and designed to be used from the
+The scripts are well-commented and designed to be used from the
 command-line. Invoke them with the `-h` flag to see their help documentation.
 
-Further documentation is available for [running the fielded_batch_ingest.py script](https://github.com/unt-libraries/django-nomination/wiki/Fielded-Batch-Ingest-Helper-Script)
-to upload bulk URL data.
 
 License
 -------

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -35,20 +35,19 @@ class Command(BaseCommand):
         parser.add_argument('-p', '--project', dest='project_slug', required=True,
                             help='identifies the project slug (required)')
         file_type_group = parser.add_mutually_exclusive_group()
-        file_type_group.add_argument('-c', '--csv', action='store_const', dest='ingest_function', const=csv_ingest, default=url_ingest,  help='file is csv format')
-        file_type_group.add_argument('-d', '--dict', action='store_const', dest='ingest_function', const=pydict_ingest, default=url_ingest, help='file is pickled dictionary format')
+        file_type_group.add_argument('-c', '--csv', action='store_const', dest='ingest_function',
+                                     const=csv_ingest, default=url_ingest,
+                                     help='file is csv format')
+        file_type_group.add_argument('-d', '--dict', action='store_const', dest='ingest_function',
+                                     const=pydict_ingest, default=url_ingest,
+                                     help='file is pickled dictionary format')
         parser.add_argument('--verify', action='store_true', dest='verify_url',
                             default=False, help='verify url is valid and available')
 
     def handle(self, *args, **options):
         """Ingest URLs from plain text, CSV, or pickled dictionary format file."""
-        ingest_function = url_ingest
-        if options['csv_file']:
-            ingest_function = csv_ingest
-        elif options['dict_file']:
-            ingest_function = pydict_ingest
-        ingest_function(options['file_name'], options['nominator_id'],
-                        options['project_slug'], options['verify_url'])
+        options['ingest_function'](options['file_name'], options['nominator_id'],
+                                   options['project_slug'], options['verify_url'])
 
 
 def url_ingest(file_name, nominator_id, project_slug, verify_url):

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -279,23 +279,22 @@ def create_url_entry_less_db(project, nominator, url_entity, url_attribute, url_
     if url_attribute == 'surt':
         if url_entity.lower() in surts_set:
             return False
-        else:
-            # Add it for future lookups to surts_set.
-            surts_set.add(url_entity.lower())
     else:
         key = '{}{}{}'.format(url_entity.lower(), url_attribute.lower(), url_value.lower())
         if key in nominator_urls_set:
             return False
-        else:
-            # Add it for future value lookups.
-            nominator_urls_set.add(key)
-
     try:
         URL.objects.create(url_project=project,
                            url_nominator=nominator,
                            entity=url_entity,
                            attribute=url_attribute,
                            value=url_value)
+        if url_attribute == 'surt':
+            # Add entity for future lookups to surts_set.
+            surts_set.add(url_entity.lower())
+        else:
+            # Add key for future value lookups.
+            nominator_urls_set.add(key)
     except IntegrityError:
         print('Failed to create a new entry for url: %s attribute: %s value: %s'
               % (url_entity, url_attribute, url_value))

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -29,27 +29,27 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Set command-line arguments."""
-        parser.add_argument("file_name", help="input file")
-        parser.add_argument("-n", "--nominator", dest="nominator_id", type=int, required=True,
-                            help="identifies the nominator id number (required)")
-        parser.add_argument("-p", "--project", dest="project_slug", required=True,
-                            help="identifies the project slug (required)")
-        parser.add_argument("-c", "--csv", action="store_true", dest="csv_file", default=False,
-                            help="file is csv format")
-        parser.add_argument("-d", "--dict", action="store_true", dest="dict_file", default=False,
-                            help="file is pickled dictionary format")
-        parser.add_argument("--verify", action="store_true", dest="verify_url",
-                            default=False, help="verify url is valid and available")
+        parser.add_argument('file_name', help='input file')
+        parser.add_argument('-n', '--nominator', dest='nominator_id', type=int, required=True,
+                            help='identifies the nominator id number (required)')
+        parser.add_argument('-p', '--project', dest='project_slug', required=True,
+                            help='identifies the project slug (required)')
+        parser.add_argument('-c', '--csv', action='store_true', dest='csv_file', default=False,
+                            help='file is csv format')
+        parser.add_argument('-d', '--dict', action='store_true', dest='dict_file', default=False,
+                            help='file is pickled dictionary format')
+        parser.add_argument('--verify', action='store_true', dest='verify_url',
+                            default=False, help='verify url is valid and available')
 
     def handle(self, *args, **options):
         """Ingest URLs from plain text, CSV, or pickled dictionary format file."""
         ingest_function = url_ingest
-        if options["csv_file"]:
+        if options['csv_file']:
             ingest_function = csv_ingest
-        elif options["dict_file"]:
+        elif options['dict_file']:
             ingest_function = pydict_ingest
-        ingest_function(options["file_name"], options["nominator_id"],
-                        options["project_slug"], options["verify_url"])
+        ingest_function(options['file_name'], options['nominator_id'],
+                        options['project_slug'], options['verify_url'])
 
 
 def url_ingest(file_name, nominator_id, project_slug, verify_url):

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -289,16 +289,16 @@ def create_url_entry_less_db(project, nominator, url_entity, url_attribute, url_
                            entity=url_entity,
                            attribute=url_attribute,
                            value=url_value)
-        if url_attribute == 'surt':
-            # Add entity for future lookups to surts_set.
-            surts_set.add(url_entity.lower())
-        else:
-            # Add key for future value lookups.
-            nominator_urls_set.add(key)
     except IntegrityError:
         print('Failed to create a new entry for url: %s attribute: %s value: %s'
               % (url_entity, url_attribute, url_value))
         return False
+    if url_attribute == 'surt':
+        # Add entity for future lookups to surts_set.
+        surts_set.add(url_entity.lower())
+    else:
+        # Add key for future value lookups.
+        nominator_urls_set.add(key)
     return True
 
 

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -20,12 +20,12 @@ nominator_urls_set = set()
 
 class Command(BaseCommand):
 
-    help = """fielded_batch_ingest - Adds urls from a text file into the URL table
-
-    example: fielded_batch_ingest.py -p <PROJECT_SLUG> -n <NOMINATOR_ID> filename
+    help = """fielded_batch_ingest - Adds urls from a text file into the URL table.
 
     Takes a list of urls from a text file (with a required project and nominator specified)
-    and adds the urls to the URL table, adding a surt attribute if none exists."""
+    and adds the urls to the URL table, adding a surt attribute if none exists.
+
+    example: fielded_batch_ingest.py -p <PROJECT_SLUG> -n <NOMINATOR_ID> filename"""
 
     def add_arguments(self, parser):
         """Set command-line arguments."""

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -65,24 +65,24 @@ def url_ingest(file_name, nominator_id, project_slug, verify_url):
     entry_count = 0
     new_entries = 0
     surt_entries = 0
-    f = open(file_name, 'r')
-    for line in f.readlines():
-        if line.isspace():
-            continue
-        url_entity = url_formatter(line)
-        if verify_url:
-            if not verifyURL(url_entity):
+    with open(file_name, 'r') as text_file:
+        for line in text_file.readlines():
+            if line.isspace():
                 continue
-        # Attempt to create new url entry
-        new_url = create_url_entry(project, nominator, url_entity, 'nomination', '1')
-        # Create a SURT if the url doesn't already have one
-        new_surt = create_url_entry(project, system_nominator, url_entity,
-                                    'surt', surtize(url_entity))
-        if new_url:
-            new_entries += 1
-        if new_surt:
-            surt_entries += 1
-        entry_count += 1
+            url_entity = url_formatter(line)
+            if verify_url:
+                if not verifyURL(url_entity):
+                    continue
+            # Attempt to create new url entry
+            new_url = create_url_entry(project, nominator, url_entity, 'nomination', '1')
+            # Create a SURT if the url doesn't already have one
+            new_surt = create_url_entry(project, system_nominator, url_entity,
+                                        'surt', surtize(url_entity))
+            if new_url:
+                new_entries += 1
+            if new_surt:
+                surt_entries += 1
+            entry_count += 1
     print('Created %s new url surt entries.' % (surt_entries))
     print('Created %s new url nomination entries out of %s possible entries.'
           % (new_entries, entry_count))
@@ -108,35 +108,35 @@ def csv_ingest(file_name, nominator_id, project_slug, verify_url):
     surts = [s.lower() for s in surts]
     global surts_set
     surts_set = set(surts)
-    csv_file = open(file_name, 'r', newline='')
     nomination_count = 0
     entry_count = 0
     surt_count = 0
     new_entry = None
-    csv_reader = csv.DictReader(csv_file)
-    for data in csv_reader:
-        url_entity = url_formatter(data['url'])
-        if verify_url:
-            if not verifyURL(url_entity):
-                continue
-        # Attempt to create new url nomination entry
-        new_nomination = create_url_entry_less_db(project, nominator, url_entity, 'nomination',
-                                                  '1')
-        # Create a SURT if the url doesn't already have one
-        new_surt = create_url_entry_less_db(project, system_nominator, url_entity, 'surt',
-                                            surtize(url_entity))
-        for attribute_name in data.keys():
-            if not attribute_name == 'url':
-                if data[attribute_name] != '':
-                    new_entry = create_url_entry_less_db(project, nominator, url_entity,
-                                                         attribute_name, data[attribute_name])
-                if new_entry:
-                    entry_count += 1
+    with open(file_name, 'r', newline='') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        for data in csv_reader:
+            url_entity = url_formatter(data['url'])
+            if verify_url:
+                if not verifyURL(url_entity):
+                    continue
+            # Attempt to create new url nomination entry
+            new_nomination = create_url_entry_less_db(project, nominator, url_entity, 'nomination',
+                                                      '1')
+            # Create a SURT if the url doesn't already have one
+            new_surt = create_url_entry_less_db(project, system_nominator, url_entity, 'surt',
+                                                surtize(url_entity))
+            for attribute_name in data.keys():
+                if not attribute_name == 'url':
+                    if data[attribute_name] != '':
+                        new_entry = create_url_entry_less_db(project, nominator, url_entity,
+                                                             attribute_name, data[attribute_name])
+                    if new_entry:
+                        entry_count += 1
 
-        if new_nomination:
-            nomination_count += 1
-        if new_surt:
-            surt_count += 1
+            if new_nomination:
+                nomination_count += 1
+            if new_surt:
+                surt_count += 1
     print('Created %s new SURT entries.' % (surt_count))
     print('Created %s new nomination entries.' % (nomination_count))
     print('Created %s other attribute entries.' % (entry_count))

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -255,8 +255,7 @@ def create_url_entry(project, nominator, url_entity, url_attribute, url_value):
                                url_nominator=nominator,
                                entity=url_entity,
                                attribute=url_attribute,
-                               value=url_value,
-                               )
+                               value=url_value)
         except IntegrityError:
             print('Failed to create a new entry for url: %s attribute: %s value: %s'
                   % (url_entity, url_attribute, url_value))
@@ -298,8 +297,7 @@ def create_url_entry_less_db(project, nominator, url_entity, url_attribute, url_
                            url_nominator=nominator,
                            entity=url_entity,
                            attribute=url_attribute,
-                           value=url_value,
-                           )
+                           value=url_value)
     except IntegrityError:
         print('Failed to create a new entry for url: %s attribute: %s value: %s'
               % (url_entity, url_attribute, url_value))

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -85,8 +85,8 @@ def url_ingest(file_name, nominator_id, project_slug, verify_url):
         if new_surt:
             surt_entries += 1
         entry_count += 1
-    print("Created %s new url surt entries." % (surt_entries))
-    print("Created %s new url nomination entries out of %s possible entries."
+    print('Created %s new url surt entries.' % (surt_entries))
+    print('Created %s new url nomination entries out of %s possible entries.'
           % (new_entries, entry_count))
 
 
@@ -139,9 +139,9 @@ def csv_ingest(file_name, nominator_id, project_slug, verify_url):
             nomination_count += 1
         if new_surt:
             surt_count += 1
-    print("Created %s new SURT entries." % (surt_count))
-    print("Created %s new nomination entries." % (nomination_count))
-    print("Created %s other attribute entries." % (entry_count))
+    print('Created %s new SURT entries.' % (surt_count))
+    print('Created %s new nomination entries.' % (nomination_count))
+    print('Created %s other attribute entries.' % (entry_count))
 
 
 def pydict_ingest(file_name, nominator_id, project_slug, verify_url):
@@ -195,9 +195,9 @@ def pydict_ingest(file_name, nominator_id, project_slug, verify_url):
         except EOFError:
             break
 
-    print("Created %s new SURT entries." % (surt_count))
-    print("Created %s new nomination entries." % (nomination_count))
-    print("Created %s other attribute entries." % (entry_count))
+    print('Created %s new SURT entries.' % (surt_count))
+    print('Created %s new nomination entries.' % (nomination_count))
+    print('Created %s other attribute entries.' % (entry_count))
     rff.close()
 
 
@@ -205,8 +205,8 @@ def get_nominator(nominator_id):
     try:
         nominator = Nominator.objects.get(id=nominator_id)
     except ObjectDoesNotExist:
-        print("Nominator ID:%s was not found in the Nominator table. Please add the nominator,"
-              " or use the correct ID." % (nominator_id))
+        print('Nominator ID:%s was not found in the Nominator table. Please add the nominator,'
+              ' or use the correct ID.' % (nominator_id))
         sys.exit()
 
     return nominator
@@ -216,7 +216,7 @@ def get_system_nominator():
     try:
         system_nominator = Nominator.objects.get(id=settings.SYSTEM_NOMINATOR_ID)
     except ObjectDoesNotExist:
-        print("Could not get the system nominator.")
+        print('Could not get the system nominator.')
         sys.exit()
 
     return system_nominator
@@ -226,8 +226,8 @@ def get_project(slug):
     try:
         project = Project.objects.get(project_slug=slug)
     except ObjectDoesNotExist:
-        print("%s was not found in the Project table. Please add the project to the"
-              " Project table." % (slug))
+        print('%s was not found in the Project table. Please add the project to the'
+              ' Project table.' % (slug))
         sys.exit()
 
     return project
@@ -258,11 +258,11 @@ def create_url_entry(project, nominator, url_entity, url_attribute, url_value):
                                value=url_value,
                                )
         except IntegrityError:
-            print("Failed to create a new entry for url: %s attribute: %s value: %s"
+            print('Failed to create a new entry for url: %s attribute: %s value: %s'
                   % (url_entity, url_attribute, url_value))
             return False
     except MultipleObjectsReturned:
-        print("Failed to create a new entry for url: %s attribute: %s value: %s"
+        print('Failed to create a new entry for url: %s attribute: %s value: %s'
               % (url_entity, url_attribute, url_value))
         return False
     else:
@@ -301,7 +301,7 @@ def create_url_entry_less_db(project, nominator, url_entity, url_attribute, url_
                            value=url_value,
                            )
     except IntegrityError:
-        print("Failed to create a new entry for url: %s attribute: %s value: %s"
+        print('Failed to create a new entry for url: %s attribute: %s value: %s'
               % (url_entity, url_attribute, url_value))
         return False
     return True
@@ -386,7 +386,7 @@ def addImpliedHttpIfNecessary(uri):
 
 class HeadRequest(Request):
     def get_method(self):
-        return "HEAD"
+        return 'HEAD'
 
 
 def verifyURL(url):
@@ -397,12 +397,12 @@ def verifyURL(url):
         print(str(e) + '; skipping URL ' + url)
         return False
     headers = {
-        "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,"
-                  "text/plain;q=0.8,image/png,*/*;q=0.5",
-        "Accept-Language": "en-us,en;q=0.5",
-        "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
-        "Connection": "close",
-        "User-Agent": "Mozilla/5.0 (X11; Linux i686)",
+        'Accept': 'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,'
+                  'text/plain;q=0.8,image/png,*/*;q=0.5',
+        'Accept-Language': 'en-us,en;q=0.5',
+        'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
+        'Connection': 'close',
+        'User-Agent': 'Mozilla/5.0 (X11; Linux i686)',
     }
     try:
         req = HeadRequest(url, None, headers)

--- a/nomination/management/commands/fielded_batch_ingest.py
+++ b/nomination/management/commands/fielded_batch_ingest.py
@@ -34,10 +34,9 @@ class Command(BaseCommand):
                             help='identifies the nominator id number (required)')
         parser.add_argument('-p', '--project', dest='project_slug', required=True,
                             help='identifies the project slug (required)')
-        parser.add_argument('-c', '--csv', action='store_true', dest='csv_file', default=False,
-                            help='file is csv format')
-        parser.add_argument('-d', '--dict', action='store_true', dest='dict_file', default=False,
-                            help='file is pickled dictionary format')
+        file_type_group = parser.add_mutually_exclusive_group()
+        file_type_group.add_argument('-c', '--csv', action='store_const', dest='ingest_function', const=csv_ingest, default=url_ingest,  help='file is csv format')
+        file_type_group.add_argument('-d', '--dict', action='store_const', dest='ingest_function', const=pydict_ingest, default=url_ingest, help='file is pickled dictionary format')
         parser.add_argument('--verify', action='store_true', dest='verify_url',
                             default=False, help='verify url is valid and available')
 

--- a/tests/data/test.csv
+++ b/tests/data/test.csv
@@ -1,0 +1,4 @@
+url,List_Name,State
+https://example1.com,file.txt,Texas
+http://example3.com,file.txt,Arkansas
+http://example3.com,file2.txt,Arkansas

--- a/tests/test_fielded_batch_ingest.py
+++ b/tests/test_fielded_batch_ingest.py
@@ -14,7 +14,6 @@ from . import factories
 TEST_DIR = pathlib.Path(__file__).resolve().parent
 CSV = TEST_DIR / 'data/test.csv'
 MOCKED_DATETIME = datetime.datetime(2025, 3, 10, 10, 15, 0)
-
 EXPECTED = [
     {'id': 1,
      'url_project_id': 1,
@@ -79,6 +78,42 @@ EXPECTED = [
      'attribute': 'List_Name',
      'value': 'file2.txt',
      'date': MOCKED_DATETIME}]
+
+
+class TestCommandHandle():
+
+    nominator = 12
+    slug = 'project1'
+
+    @patch('nomination.management.commands.fielded_batch_ingest.url_ingest')
+    def test_command_handle_url_ingest(self, mocked_url_ingest):
+        input_file = 'seeds.txt'
+        call_command('fielded_batch_ingest',
+                     input_file,
+                     f'--nominator={self.nominator}',
+                     f'--project={self.slug}',
+                     '--verify')
+        mocked_url_ingest.assert_called_once_with(input_file, self.nominator, self.slug, True)
+
+    @patch('nomination.management.commands.fielded_batch_ingest.csv_ingest')
+    def test_command_handle_csv_ingest(self, mocked_csv_ingest):
+        input_file = 'seeds.csv'
+        call_command('fielded_batch_ingest',
+                     input_file,
+                     f'--nominator={self.nominator}',
+                     f'--project={self.slug}',
+                     '--csv')
+        mocked_csv_ingest.assert_called_once_with(input_file, self.nominator, self.slug, False)
+
+    @patch('nomination.management.commands.fielded_batch_ingest.pydict_ingest')
+    def test_command_handle_pydict_ingest(self, mocked_pydict_ingest):
+        input_file = 'data.pkl'
+        call_command('fielded_batch_ingest',
+                     input_file,
+                     f'--nominator={self.nominator}',
+                     f'--project={self.slug}',
+                     '--dict')
+        mocked_pydict_ingest.assert_called_once_with(input_file, self.nominator, self.slug, False)
 
 
 @pytest.mark.django_db

--- a/tests/test_fielded_batch_ingest.py
+++ b/tests/test_fielded_batch_ingest.py
@@ -1,0 +1,172 @@
+import datetime
+import pathlib
+from unittest.mock import patch, Mock
+
+from django.core.management import call_command
+import pytest
+
+from nomination.management.commands import fielded_batch_ingest
+from nomination.models import URL
+from . import factories
+
+
+TEST_DIR = pathlib.Path(__file__).resolve().parent
+CSV = TEST_DIR / 'data/test.csv'
+MOCKED_DATETIME = datetime.datetime(2025, 3, 10, 10, 15, 0)
+
+EXPECTED = [
+    {'id': 1,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'https://example1.com',
+     'attribute': 'nomination',
+     'value': '1',
+     'date': MOCKED_DATETIME},
+    {'id': 2,
+     'url_project_id': 1,
+     'url_nominator_id': 1,
+     'entity': 'https://example1.com',
+     'attribute': 'surt',
+     'value': 'http://(com,example1,)',
+     'date': MOCKED_DATETIME},
+    {'id': 3,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'https://example1.com',
+     'attribute': 'List_Name',
+     'value': 'file.txt',
+     'date': MOCKED_DATETIME},
+    {'id': 4,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'https://example1.com',
+     'attribute': 'State',
+     'value': 'Texas',
+     'date': MOCKED_DATETIME},
+    {'id': 5,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'http://example3.com',
+     'attribute': 'nomination',
+     'value': '1',
+     'date': MOCKED_DATETIME},
+    {'id': 6,
+     'url_project_id': 1,
+     'url_nominator_id': 1,
+     'entity': 'http://example3.com',
+     'attribute': 'surt',
+     'value': 'http://(com,example3,)',
+     'date': MOCKED_DATETIME},
+    {'id': 7,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'http://example3.com',
+     'attribute': 'List_Name',
+     'value': 'file.txt',
+     'date': MOCKED_DATETIME},
+    {'id': 8,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'http://example3.com',
+     'attribute': 'State',
+     'value': 'Arkansas',
+     'date': MOCKED_DATETIME},
+    {'id': 9,
+     'url_project_id': 1,
+     'url_nominator_id': 2,
+     'entity': 'http://example3.com',
+     'attribute': 'List_Name',
+     'value': 'file2.txt',
+     'date': MOCKED_DATETIME}]
+ 
+
+@pytest.mark.django_db
+@patch('django.utils.timezone.now', Mock(return_value=MOCKED_DATETIME))
+class TestCSVIngest():
+
+    def test_csv_ingest(self, capsys):
+        project = factories.ProjectFactory()
+        nominator = factories.NominatorFactory()
+
+        # load contents of test.csv, that is:
+        # url,List_Name,State
+        # https://example1.com,file.txt,Texas
+        # http://example3.com,file.txt,Arkansas
+        # http://example3.com,file2.txt,Arkansas
+
+        call_command('fielded_batch_ingest',
+                     CSV,
+                     f'--nominator={nominator.id}',
+                     f'--project={project.project_slug}',
+                     '--csv')
+
+        captured = capsys.readouterr()
+        # Ingesting 2 unique URLs results in 2 new SURTs and 2 new nominations.
+        # Other 5 attributes added for the 2 URLs are:
+        # https://example1.com: (1) state of Texas, List_Name of (2) file.txt
+        # http://example3.com: (3) state of Arkansas, List_Name of (4) file1.txt and (5) file2.txt
+        assert captured.out == ('Created 2 new SURT entries.\n'
+                                'Created 2 new nomination entries.\n'
+                                'Created 5 other attribute entries.\n')
+        assert list(URL.objects.all().values()) == EXPECTED
+
+
+    def test_csv_ingest_reingest_does_nothing(self, capsys):
+        """Verify running the same file a second time does nothing."""
+        project = factories.ProjectFactory()
+        nominator = factories.NominatorFactory()
+
+        call_command('fielded_batch_ingest',
+                     CSV,
+                     f'--nominator={nominator.id}',
+                     f'--project={project.project_slug}',
+                     '--csv')
+
+        captured = capsys.readouterr()
+        assert captured.out == ('Created 2 new SURT entries.\n'
+                                'Created 2 new nomination entries.\n'
+                                'Created 5 other attribute entries.\n')
+
+        # Run the command again with the same file, and verify nothing changes.
+        call_command('fielded_batch_ingest',
+                     CSV,
+                     f'--nominator={nominator.id}',
+                     f'--project={project.project_slug}',
+                     '--csv')
+
+        captured = capsys.readouterr()
+        assert captured.out == ('Created 0 new SURT entries.\n'
+                                'Created 0 new nomination entries.\n'
+                                'Created 0 other attribute entries.\n')
+
+        assert list(URL.objects.all().values()) == EXPECTED
+
+
+@pytest.mark.django_db
+class TestCreateURLEntryLessDB:
+
+    @patch('nomination.management.commands.fielded_batch_ingest.surts_set',
+           {'https://example1.com'})
+    def test_create_url_entry_less_db_surt_exists(self):
+        """Verify we don't create another SURT for an already-nominated URL."""
+        project = factories.ProjectFactory()
+        nominator = factories.NominatorFactory()
+        result = fielded_batch_ingest.create_url_entry_less_db(project,
+                                                               nominator,
+                                                              'https://example1.com',
+                                                              'surt',
+                                                              'http://(com,example1,)')
+        assert not result
+
+
+class TestURLFormatter:
+    
+    test_data = [
+        (' www.example.com ', 'http://www.example.com'),
+        ('http://www.example.com/pdfs/a file.pdf', 'http://www.example.com/pdfs/a%20file.pdf'),
+        ('https://www.example.com/', 'https://www.example.com'),
+    ]
+
+    @pytest.mark.parametrize('input_url,output_url', test_data)
+    def test_url_formatter(self, input_url, output_url):
+        assert fielded_batch_ingest.url_formatter(input_url) == output_url


### PR DESCRIPTION
This converts the fielded_batch_ingest.py script to a management command to facilitate running it in the Django ecosystem. It adds a function `create_url_entry_less_db` for an alternative way of more quickly loading files of bulk URL nominations because the old function is very slow with its repeated database lookups particularly for projects containing many hundreds of thousands of URLs. I have added tests for the changed functionality, but not for the existing functionality that doesn't really get used in practice and may be going away.

ping @clarktr1 @somexpert this is ready for review. Some instructions for running the command may be found in the README. Let me know if you have questions.