### PR TITLE
Fix url lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Change Log
 * Upgraded to Django 4.2.
 * Fixed nominating URLs of length 255-300 chars by ensuring `value` is big enough to hold the URL's SURT value. [#114](https://github.com/unt-libraries/django-nomination/issues/114)
 * Fixed browsing from listing page to top-level domain SURT URLs. [#115](https://github.com/unt-libraries/django-nomination/issues/115)
+* Fixed links in URL lookup search results that needed encoding. [#118](https://github.com/unt-libraries/django-nomination/issues/118)
 
 
 4.0.0

--- a/nomination/templates/nomination/url_search_results.html
+++ b/nomination/templates/nomination/url_search_results.html
@@ -15,7 +15,7 @@
                     <ul class="list-unstyled">
                         {% for url_item in url_list %}
                             <li>
-                                <a href="/nomination/{{ project.project_slug }}/url/{{ url_item.entity }}/">{{ url_item.entity }}</a>
+                                <a href="{% url 'url_listing' project.project_slug url_item.entity %}">{{ url_item.entity }}</a>
                             </li>
                         {% endfor %}
                     </ul>

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -3,3 +3,4 @@ pytest>=2.8.2
 pytest-django>=2.9.0
 factory_boy>=2.6.0
 pytest-cov>=2.2.0
+python-dateutil>=2.9.0


### PR DESCRIPTION
This is to fix #118.

Using the `url` template tag takes care of making the url entity safe to include in an URL. It encodes the `?` of the query string and escapes the url for use in HTML.