### PR TITLE
Update bookmarklet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Change Log
 * Fixed browsing from listing page to top-level domain SURT URLs. [#115](https://github.com/unt-libraries/django-nomination/issues/115)
 * Fixed links in URL lookup search results that needed encoding. [#118](https://github.com/unt-libraries/django-nomination/issues/118)
 * Converted fielded_batch_ingest.py script to a Django management command and improved speed.
+* Updated info about bookmarklets. [#120](https://github.com/unt-libraries/django-nomination/issues/120)
 
 
 4.0.0

--- a/nomination/templates/nomination/project_about.html
+++ b/nomination/templates/nomination/project_about.html
@@ -68,39 +68,16 @@
                 </div>
                 <div class="panel-body">
                     <p>
-                        A bookmarklet is a brief javascript program that can be stored as a bookmark
+                        A bookmarklet is a brief JavaScript program that can be stored as a bookmark
                         or favorite in your browser. By following the instructions below you may add
                         a bookmarklet to your toolbar that allows you to easily nominate URLs to
                         this project while you browse the Web.
                     </p>
-                    <dl>
-                        <dt>Firefox</dt>
-                        <dd>
-                            If your Bookmarks Toolbar is not visible, navigate to menu View-&gt;Toolbars,
-                            and select "Bookmarks Toolbar." Drag this link
-                            <a href="javascript:window.open('http://{{current_host}}/nomination/{{project.project_slug}}/url/'+escape(location.href.replace(/\/$/, '')+'/')).focus();">
-                                {{project.project_slug}} Nominator
-                            </a> to the Bookmarks Toolbar.
-                        </dd>
-                        <dt>Google Chrome</dt>
-                        <dd>
-                            If your Bookmarks Bar is not visible, use the keyboard command
-                            <kbd>Shift+Ctrl+B</kbd> to make it so, or navigate to menu Tools and select
-                            "Always Show Bookmarks Bar." Drag this link
-                            <a href="javascript:window.open('http://{{current_host}}/nomination/{{project.project_slug}}/url/'+escape(location.href.replace(/\/$/, '')+'/')).focus();">
-                                {{project.project_slug}} Nominator
-                            </a> to the Bookmarks Toolbar.
-                        </dd>
-                        <dt>Internet Explorer</dt>
-                        <dd>
-                            If your Links Toolbar is not visible, right click on the menu bar and select
-                            "Links." Right click on this link
-                            <a href="javascript:window.open('http://{{current_host}}/nomination/{{project.project_slug}}/url/'+escape(location.href.replace(/\/$/, '')+'/')).focus();">
-                                {{project.project_slug}} Nominator
-                            </a>, and select "Add to Favorites..." For the "Create in" field, select
-                            "Links" then click "Add."
-                        </dd>
-                    </dl>
+                    <p>
+                        In Chrome, Edge, or Firefox, if your Bookmarks or Favorites Bar is not visible, use the keyboard command
+                        <kbd>Shift+Ctrl+B</kbd> to make it so. Then drag this link
+                        <a href="javascript:window.open('{{ url_base }}'+escape(location.href.replace(/\/$/, '')+'/')).focus();">{{project.project_slug}} Nominator</a> to the Bookmarks/Favorites Toolbar.
+                    </p>
                 </div>
             </div>
         {% endif %} 

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -1,6 +1,5 @@
 import json
 import datetime
-import os
 import re
 
 from urllib.parse import quote, unquote
@@ -553,8 +552,10 @@ def project_about(request, slug):
         host = request.META.get('HTTP_HOST', '')
         if not host:
             host = get_object_or_404(Site, id=settings.SITE_ID)
-        base_path = os.path.join(reverse('project_urls', args=[project.project_slug]),
-                                 'url/')
+        # get path for url_listing view without the last argument and end slash
+        rm_arg = 'url_arg_to_remove'
+        url_path = reverse('url_listing', args=[project.project_slug, rm_arg])
+        base_path = url_path.rstrip('/')[:-len(rm_arg)]
         url_base = '{}{}{}'.format(scheme, host, base_path)
 
     return render(

--- a/nomination/views.py
+++ b/nomination/views.py
@@ -1,5 +1,6 @@
 import json
 import datetime
+import os
 import re
 
 from urllib.parse import quote, unquote
@@ -13,6 +14,7 @@ from django import forms
 from django.views.decorators.csrf import csrf_protect
 from django.utils.encoding import iri_to_uri
 from django.contrib.sites.models import Site
+from django.urls import reverse
 
 from nomination.models import Project, URL, Nominator
 from nomination.url_handler import (
@@ -542,9 +544,19 @@ def project_about(request, slug):
     urls = URL.objects.filter(url_project__project_slug__exact=slug)
     url_count = get_project_url_count(urls)
     nominator_count = get_project_nominator_count(urls)
-    current_host = get_object_or_404(Site, id=settings.SITE_ID)
     # figure out if we need to show bookmarklets
     show_bookmarklets = datetime.datetime.now() < project.nomination_end
+    url_base = ''
+    if show_bookmarklets:
+        # construct the bookmarklet nomination URL, if using
+        scheme = getattr(settings, 'SITE_SCHEME', 'http://')
+        host = request.META.get('HTTP_HOST', '')
+        if not host:
+            host = get_object_or_404(Site, id=settings.SITE_ID)
+        base_path = os.path.join(reverse('project_urls', args=[project.project_slug]),
+                                 'url/')
+        url_base = '{}{}{}'.format(scheme, host, base_path)
+
     return render(
         request,
         'nomination/project_about.html',
@@ -552,7 +564,7 @@ def project_about(request, slug):
          'project': project,
          'url_count': url_count,
          'nominator_count': nominator_count,
-         'current_host': current_host,
+         'url_base': url_base,
          'show_bookmarklets': show_bookmarklets,
         },
         )


### PR DESCRIPTION
This is to fix #120. We have outdated info about using bookmarklets with various browsers, since Internet Explorer is no longer supported. I switched to generating the nomination URL for the bookmarklet JavaScript in the view because of not wanting to hardcode the scheme and parts of the URL in the template.